### PR TITLE
Add clj-kondo config with reagent.core/with-let lint-as definition

### DIFF
--- a/template/.clj-kondo/config.edn
+++ b/template/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {reagent.core/with-let clojure.core/let}}


### PR DESCRIPTION
As reagent is part of the project, clj-kondo will output an info message when you use reagent's with-let macro. To help with this, I added a clj-kondo config file into the template with reagent.core/with-let being linted similarly to let macro.

Hopefully I made the change to the template correctly, this was my first time working with npx templates.