### PR TITLE
Cider configuration has been added to the template tree 

### DIFF
--- a/template/.dir-locals.el
+++ b/template/.dir-locals.el
@@ -1,0 +1,2 @@
+((nil . ((cider-default-cljs-repl . shadow)
+         (cider-shadow-cljs-default-options . "app"))))


### PR DESCRIPTION
First of all kudos mate. It is really a helpful and handy tool.

I've added the project wide configuration for `Cider` to the template tree. This way cider can work nicer alongside the projects that are created using this template.