### PR TITLE
switch yarn to npm in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sc": "shadow-cljs",
     "server": "shadow-cljs stop && shadow-cljs start",
     "start": "shadow-cljs watch lib",
-    "build": "yarn clean && shadow-cljs release lib",
+    "build": "npm run clean && shadow-cljs release lib",
     "test": "shadow-cljs watch test --config-merge \"{:autorun true}\"",
     "test:once": "shadow-cljs compile test && node out/test.js",
     "e2e": "shadow-cljs compile e2e && node out/e2e.js",


### PR DESCRIPTION
Yarn is not installed on my computer, so when i run `build` script i got an error. Npm should default script runner.